### PR TITLE
Fix zero-contrast in pseudo-C by properly marking the code chunk

### DIFF
--- a/_posts/2015-03-27-rust-xxdb.md
+++ b/_posts/2015-03-27-rust-xxdb.md
@@ -119,10 +119,10 @@ fundamental things as accessing elements in a slice, accessing fields of an enum
 or tuple, anything that uses auto-dereferencing, or calling Rust-defined
 methods, functions, or closures.
 
-If the you know the internal representation of things you can do some funky
+If you know the internal representation of things you can do some funky
 stuff like using C pointer arithmetic to access elements in a slice:
 
-```C
+```c
 print slice.data_ptr[3]
 ```
 


### PR DESCRIPTION
I mean, I can't test it because it's some Very Custom thingy, but this is p bad:
![screenshot](https://user-images.githubusercontent.com/6709544/38137265-0b1c8d40-3424-11e8-9a53-bf0f9628c9c0.png)